### PR TITLE
Adding a getUserId function

### DIFF
--- a/force.js
+++ b/force.js
@@ -64,7 +64,7 @@ var force = (function () {
         oauthRedirectURL = params.oauthRedirectURL || oauthRedirectURL;
         proxyURL = params.proxyURL || proxyURL;
         loginUrl = params.loginUrl || loginUrl;
- 
+
 
         // Load previously saved token
         if (tokenStore['forceOAuth']) {
@@ -163,6 +163,14 @@ var force = (function () {
         } else {
             if (loginErrorHandler) loginErrorHandler({status: 'access_denied'});
         }
+    }
+
+    /**
+     * Gets the user's ID (if logged in)
+     * @returns {string} | undefined
+     */
+    function getUserId() {
+        return (typeof(oauth) !== 'undefined') ? oauth.id.split('/').pop() : undefined;
     }
 
     /**
@@ -443,6 +451,7 @@ var force = (function () {
         init: init,
         login: login,
         isLoggedIn: isLoggedIn,
+        getUserId: getUserId,
         request: request,
         query: query,
         create: create,


### PR DESCRIPTION
Adds a function to retrieve the _userID_ for the logged in user.

Note I have stripped the userID from the full value that is being reported back following the login. 
i.e. if _oauth.id_ = "https://login.salesforce.com/id/00DR0000000ABCDMAK/00520000001ABCoAAO" then _force.getUserId()_  returns _"00520000001ABCoAAO"_
