### PR TITLE
Recognize the window.sforce object as an indication that we don't nee…

### DIFF
--- a/force.js
+++ b/force.js
@@ -51,9 +51,9 @@ var force = (function () {
     // Reference to the Salesforce OAuth plugin
         oauthPlugin,
 
-    // Whether or not to use a CORS proxy. Defaults to false if app running in Cordova or in a VF page
-    // Can be overriden in init()
-        useProxy = (window.cordova || window.SfdcApp) ? false : true;
+    // Whether or not to use a CORS proxy. Defaults to false if app running in Cordova, in a VF page,
+    // or using the Salesforce console. Can be overriden in init()
+        useProxy = (window.cordova || window.SfdcApp || window.sforce) ? false : true;
 
     /*
      * Determines the request base URL.


### PR DESCRIPTION
We were experiencing issues in our Salesforce Support Console due to the wrong URL being used for a force.create() call. We isolated the issue to be that getRequestBaseURL() was pointing us to the proxyURL because useProxy was true. useProxy was true because window.SfdcApp was not defined in some parts of our console where we were using the forceJS library. window.sforce *is* defined however. So I've added a check to see if that property is defined and if so we determine the proxy isn't needed.