### PR TITLE
Added loginURLParams init option

### DIFF
--- a/force.js
+++ b/force.js
@@ -49,7 +49,7 @@ let // The login URL for the OAuth process
     useProxy = (window.cordova || window.SfdcApp || window.sforce) ? false : true,
     
     //Additional login window URL parameters for customizing the desktop login experience
-    loginURLParameters = {};
+    loginURLParams = {};
 
 /*
  * Determines the request base URL.

--- a/force.js
+++ b/force.js
@@ -265,7 +265,13 @@ export let loginWithBrowser = () => new Promise((resolve, reject) => {
     console.log('loginURL: ' + loginURL);
     console.log('oauthCallbackURL: ' + oauthCallbackURL);
 
-    let loginWindowURL = loginURL + '/services/oauth2/authorize?client_id=' + appId + '&redirect_uri=' + oauthCallbackURL + '&response_type=token' + toQueryString(loginURLParams);
+    let addlParams = toQueryString(loginURLParams);
+    
+    if(addlParams) {
+        addlParams = `&${addlParams}`
+    }
+
+    let loginWindowURL = `${loginURL}/services/oauth2/authorize?client_id=${appId}&redirect_uri=${oauthCallbackURL}&response_type=token${addlParams}`;
 
     document.addEventListener("oauthCallback", (event) => {
 

--- a/force.js
+++ b/force.js
@@ -49,8 +49,7 @@ let // The login URL for the OAuth process
     useProxy = (window.cordova || window.SfdcApp || window.sforce) ? false : true,
     
     //Additional login window URL parameters for customizing the desktop login experience
-    loginURLParameters = {}
-    ;
+    loginURLParameters = {};
 
 /*
  * Determines the request base URL.

--- a/force.js
+++ b/force.js
@@ -46,7 +46,11 @@ let // The login URL for the OAuth process
 
     // Whether or not to use a CORS proxy. Defaults to false if app running in Cordova, in a VF page,
     // or using the Salesforce console. Can be overriden in init()
-    useProxy = (window.cordova || window.SfdcApp || window.sforce) ? false : true;
+    useProxy = (window.cordova || window.SfdcApp || window.sforce) ? false : true,
+    
+    //Additional login window URL parameters for customizing the desktop login experience
+    loginURLParameters = {}
+    ;
 
 /*
  * Determines the request base URL.
@@ -261,7 +265,7 @@ export let loginWithBrowser = () => new Promise((resolve, reject) => {
     console.log('loginURL: ' + loginURL);
     console.log('oauthCallbackURL: ' + oauthCallbackURL);
 
-    let loginWindowURL = loginURL + '/services/oauth2/authorize?client_id=' + appId + '&redirect_uri=' + oauthCallbackURL + '&response_type=token';
+    let loginWindowURL = loginURL + '/services/oauth2/authorize?client_id=' + appId + '&redirect_uri=' + oauthCallbackURL + '&response_type=token' + toQueryString(loginURLParams);
 
     document.addEventListener("oauthCallback", (event) => {
 

--- a/force.js
+++ b/force.js
@@ -192,6 +192,7 @@ export let init = params => {
         oauthCallbackURL = params.oauthCallbackURL || oauthCallbackURL;
         proxyURL = params.proxyURL || proxyURL;
         useProxy = params.useProxy === undefined ? useProxy : params.useProxy;
+        loginURLParams = params.loginURLParams || loginURLParams;
 
         if (params.accessToken) {
             if (!oauth) oauth = {};

--- a/lib/force.js
+++ b/lib/force.js
@@ -49,7 +49,10 @@ oauthPlugin = undefined,
 
 // Whether or not to use a CORS proxy. Defaults to false if app running in Cordova, in a VF page,
 // or using the Salesforce console. Can be overriden in init()
-useProxy = window.cordova || window.SfdcApp || window.sforce ? false : true;
+useProxy = window.cordova || window.SfdcApp || window.sforce ? false : true,
+
+//Additional login window URL parameters for customizing the desktop login experience
+loginURLParameters = {};
 
 /*
  * Determines the request base URL.
@@ -262,7 +265,7 @@ var loginWithBrowser = function loginWithBrowser() {
         console.log('loginURL: ' + loginURL);
         console.log('oauthCallbackURL: ' + oauthCallbackURL);
 
-        var loginWindowURL = loginURL + '/services/oauth2/authorize?client_id=' + appId + '&redirect_uri=' + oauthCallbackURL + '&response_type=token';
+        var loginWindowURL = loginURL + '/services/oauth2/authorize?client_id=' + appId + '&redirect_uri=' + oauthCallbackURL + '&response_type=token' + toQueryString(loginURLParams);
 
         document.addEventListener("oauthCallback", function (event) {
 

--- a/lib/force.js
+++ b/lib/force.js
@@ -190,6 +190,7 @@ var init = function init(params) {
         oauthCallbackURL = params.oauthCallbackURL || oauthCallbackURL;
         proxyURL = params.proxyURL || proxyURL;
         useProxy = params.useProxy === undefined ? useProxy : params.useProxy;
+        loginURLParams = params.loginURLParams || loginURLParams;
 
         if (params.accessToken) {
             if (!oauth) oauth = {};

--- a/lib/force.js
+++ b/lib/force.js
@@ -52,7 +52,7 @@ oauthPlugin = undefined,
 useProxy = window.cordova || window.SfdcApp || window.sforce ? false : true,
 
 //Additional login window URL parameters for customizing the desktop login experience
-loginURLParameters = {};
+loginURLParams = {};
 
 /*
  * Determines the request base URL.

--- a/lib/force.js
+++ b/lib/force.js
@@ -266,7 +266,13 @@ var loginWithBrowser = function loginWithBrowser() {
         console.log('loginURL: ' + loginURL);
         console.log('oauthCallbackURL: ' + oauthCallbackURL);
 
-        var loginWindowURL = loginURL + '/services/oauth2/authorize?client_id=' + appId + '&redirect_uri=' + oauthCallbackURL + '&response_type=token' + toQueryString(loginURLParams);
+        var addlParams = toQueryString(loginURLParams);
+
+        if (addlParams) {
+            addlParams = '&' + addlParams;
+        }
+
+        var loginWindowURL = loginURL + '/services/oauth2/authorize?client_id=' + appId + '&redirect_uri=' + oauthCallbackURL + '&response_type=token' + addlParams;
 
         document.addEventListener("oauthCallback", function (event) {
 


### PR DESCRIPTION
Added an option to pass additional URL parameters to the desktop login window, so we can support all the flags shown here:

https://developer.salesforce.com/page/Digging_Deeper_into_OAuth_2.0_on_Force.com#Obtaining_an_Access_Token_in_a_Web_Application_.28Web_Server_Flow.29
