### PR TITLE
 Fixing getAttachment - adding support for downloading binary

### DIFF
--- a/force.js
+++ b/force.js
@@ -349,17 +349,28 @@ var force = (function () {
                 errorHandler('Salesforce Mobile SDK OAuth plugin not available');
                 return;
             }
+
+            var authSuccess = function(creds) {
+                // Initialize ForceJS
+                init({accessToken: creds.accessToken, instanceURL: creds.instanceUrl, refreshToken: creds.refreshToken});
+                if (typeof successHandler === "function") successHandler();
+            };
+
+            var authFailure = function(error) {
+                console.log(error);
+                if (typeof errorHandler === "function") errorHandler(error);
+            };
+
             oauthPlugin.getAuthCredentials(
-                function (creds) {
-                    // Initialize ForceJS
-                    init({accessToken: creds.accessToken, instanceURL: creds.instanceUrl, refreshToken: creds.refreshToken});
-                    if (typeof successHandler === "function") successHandler();
-                },
-                function (error) {
-                    console.log(error);
-                    if (typeof errorHandler === "function") errorHandler(error);
+                authSuccess,
+                function() {
+                    oauthPlugin.authenticate(
+                        authSuccess,
+                        authFailure
+                    );
                 }
             );
+            
         }, false);
     }
 

--- a/force.js
+++ b/force.js
@@ -411,17 +411,18 @@ var force = (function () {
      *  headerParams: parameters to send as header values for POST/PATCH etc - Optional
      * @param successHandler - function to call back when request succeeds - Optional
      * @param errorHandler - function to call back when request fails - Optional
+     * @param returnResponseAsBlob - if true, successHandler is passed a Blob - if false, successHandler is passed a JSON object - Optional
      */
-    function request(obj, successHandler, errorHandler) {
+    function request(obj, successHandler, errorHandler, returnResponseAsBlob) {
         if (typeof requestHandler === "function") {
             return requestHandler(obj);
         }
         
         // NB: networkPlugin will be defined only if login was done through plugin and container is using Mobile SDK 5.0 or above
         if (networkPlugin) { 
-            requestWithPlugin(obj, successHandler, errorHandler);
+            requestWithPlugin(obj, successHandler, errorHandler, returnResponseAsBlob);
         } else {
-            requestWithBrowser(obj, successHandler, errorHandler);
+            requestWithBrowser(obj, successHandler, errorHandler, returnResponseAsBlob);
         }
     }        
 
@@ -449,12 +450,12 @@ var force = (function () {
         }
     }
 
-    function requestWithPlugin(obj, successHandler, errorHandler) {
+    function requestWithPlugin(obj, successHandler, errorHandler, returnResponseAsBlob) {
         var obj2 = computeEndPointIfMissing(obj.endPoint, obj.path);
-        networkPlugin.sendRequest(obj2.endPoint, obj2.path, successHandler, errorHandler, obj.method, obj.data || obj.params, obj.headerParams);        
+        networkPlugin.sendRequest(obj2.endPoint, obj2.path, successHandler, errorHandler, obj.method, obj.data || obj.params, obj.headerParams, null /* file params */, returnResponseAsBlob);
     }
 
-    function requestWithBrowser(obj, successHandler, errorHandler) {
+    function requestWithBrowser(obj, successHandler, errorHandler, returnResponseAsBlob) {
         if (!oauth || (!oauth.access_token && !oauth.refresh_token)) {
             if (typeof errorHandler === "function") {
                 errorHandler('No access token. Login and try again.');
@@ -481,7 +482,11 @@ var force = (function () {
             if (xhr.readyState === 4) {
                 if (xhr.status > 199 && xhr.status < 300) {
                     if (typeof successHandler === "function") {
-                        successHandler(xhr.responseText ? JSON.parse(xhr.responseText) : undefined);
+                        if (returnResponseAsBlob) {
+                            successHandler(xhr.response);
+                        } else {
+                            successHandler(xhr.responseText ? JSON.parse(xhr.responseText) : undefined);
+                        }
                     }
                 } else if (xhr.status === 401 && oauth.refresh_token) {
                     refreshToken(
@@ -525,6 +530,9 @@ var force = (function () {
         }
         if (useProxy) {
             xhr.setRequestHeader("Target-URL", oauth.instance_url);
+        }
+        if (returnResponseAsBlob) {
+            xhr.responseType = "blob";
         }
         xhr.send(obj.data ? JSON.stringify(obj.data) : undefined);
     }
@@ -715,12 +723,13 @@ var force = (function () {
      * @param errorHandler
      */
     function getAttachment(id, successHandler, errorHandler){
-        requestBinary(
+        request(
             {
                 path: '/services/data/' + apiVersion + '/sobjects/Attachment/' + id + '/Body'
             },
             successHandler,
-            errorHandler
+            errorHandler,
+            true /* return binary */
         );
     }
 


### PR DESCRIPTION
The cordova plugin changes for downloading binary are in SDK 6.0.

Also changes to reflect the fact that getAuthCredentials does not trigger a login flow if not authenticated